### PR TITLE
Fix code scanning alert no. 4: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/AesFileEncryptor.java
+++ b/AesFileEncryptor.java
@@ -1,4 +1,6 @@
 import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import java.security.SecureRandom;
 import javax.crypto.CipherOutputStream;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
@@ -14,7 +16,7 @@ public class AesFileEncryptor {
 
     private static final String PASSWORD = "@34sfgrvxs";
     private static final String SALT = "some_random_salt";  // A static salt or generate dynamically
-    private static final String ALGORITHM = "AES/CBC/PKCS5Padding";
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
     private static final int KEY_LENGTH = 256; // AES key length
 
     public static void main(String[] args) {
@@ -34,13 +36,14 @@ public class AesFileEncryptor {
         SecretKeySpec secretKey = getSecretKey(password);
 
         // Generate a random initialization vector (IV)
-        byte[] iv = new byte[16]; // 16 bytes IV for AES (128 bits block size)
-        Arrays.fill(iv, (byte) 0);  // Just using a simple IV for now
-        IvParameterSpec ivSpec = new IvParameterSpec(iv);
+        byte[] iv = new byte[12]; // 12 bytes IV for GCM mode
+        SecureRandom secureRandom = new SecureRandom();
+        secureRandom.nextBytes(iv);
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, iv); // 128-bit authentication tag length
 
         // Initialize Cipher for encryption
         Cipher cipher = Cipher.getInstance(ALGORITHM);
-        cipher.init(Cipher.ENCRYPT_MODE, secretKey, ivSpec);
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, gcmSpec);
 
         // Open file streams
         try (FileInputStream fis = new FileInputStream(new File(inputFilePath));


### PR DESCRIPTION
Fixes [https://github.com/Vishnuj-n/Encryptify/security/code-scanning/4](https://github.com/Vishnuj-n/Encryptify/security/code-scanning/4)

To fix the problem, we need to replace the use of "AES/CBC/PKCS5Padding" with "AES/GCM/NoPadding". GCM mode provides both encryption and integrity protection, making it more secure than CBC mode. Additionally, we need to generate a secure random IV for each encryption operation.

Steps to fix:
1. Change the `ALGORITHM` constant to "AES/GCM/NoPadding".
2. Update the IV generation to use a secure random IV.
3. Adjust the cipher initialization to accommodate the GCM mode.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
