### PR TITLE
Potential fix for code scanning alert no. 7: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/security/Decrypt.java
+++ b/security/Decrypt.java
@@ -1,7 +1,7 @@
 package security;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.File;
 import java.io.FileInputStream;
@@ -19,15 +19,16 @@ public class Decrypt {
     public void decryptFile(String filePath) throws Exception {
         File inputFile = new File(filePath);
         FileInputStream inputStream = new FileInputStream(inputFile);
-        byte[] ivBytes = new byte[16];
+        // GCM recommends 12-byte IV
+        byte[] ivBytes = new byte[12];
         inputStream.read(ivBytes);
-        IvParameterSpec iv = new IvParameterSpec(ivBytes);
+        GCMParameterSpec gcmSpec = new GCMParameterSpec(128, ivBytes);
 
-        byte[] inputBytes = new byte[(int) inputFile.length() - 16];
+        byte[] inputBytes = new byte[(int) inputFile.length() - 12];
         inputStream.read(inputBytes);
 
-        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
-        cipher.init(Cipher.DECRYPT_MODE, secretKey, iv);
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.DECRYPT_MODE, secretKey, gcmSpec);
         byte[] outputBytes = cipher.doFinal(inputBytes);
 
         String outputFilePath = filePath.replace(".enc", "");


### PR DESCRIPTION
Potential fix for [https://github.com/Vishnuj-n/Encryptify/security/code-scanning/7](https://github.com/Vishnuj-n/Encryptify/security/code-scanning/7)

To address this issue, we should move from `"AES/CBC/PKCS5Padding"` to `"AES/GCM/NoPadding"`, and refactor the logic to use GCM mode. GCM provides both confidentiality and integrity by producing and verifying an authentication tag. This change will require us to:

- Change the Cipher instance and mode to `"AES/GCM/NoPadding"`.
- Use `GCMParameterSpec` instead of `IvParameterSpec`.
- Use a 12-byte IV (recommended for GCM; current code uses 16 bytes).
- Read the IV accordingly (first 12 bytes from file).
- Adjust how the encrypted data and tag are handled (when decrypting, the authentication tag is appended at the end of ciphertext, which Java’s `Cipher` handles natively given proper GCM setup).
- Import `javax.crypto.spec.GCMParameterSpec`.

Every other aspect of the code (file structure, key derivation, etc.) remains unchanged for now.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
